### PR TITLE
Update the ScalaStyle library to support trailing commas

### DIFF
--- a/src/functionalTest/groovy/org/github/alisiikh/scalastyle/ScalaStyleParsesTrailingCommas.groovy
+++ b/src/functionalTest/groovy/org/github/alisiikh/scalastyle/ScalaStyleParsesTrailingCommas.groovy
@@ -1,0 +1,21 @@
+package org.github.alisiikh.scalastyle
+
+import org.gradle.testkit.runner.BuildResult
+
+import static org.gradle.testkit.runner.TaskOutcome.NO_SOURCE
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class ScalaStyleParsesTrailingCommas extends ScalastyleFunSpec {
+    @Override
+    String getProjectName() { Projects.TRAILING_COMMA }
+
+    def "should correctly parse projects with trailing comma sources"() {
+        when:
+        BuildResult result = runGradleAndSucceed('scalastyleCheck')
+
+        then: "compiled successfully"
+        result.task(":scalastyleCheck").outcome == SUCCESS
+        result.task(':scalastyleMainCheck').outcome == SUCCESS
+        result.task(':scalastyleTestCheck').outcome == NO_SOURCE
+    }
+}

--- a/src/functionalTest/groovy/org/github/alisiikh/scalastyle/ScalastyleFunSpec.groovy
+++ b/src/functionalTest/groovy/org/github/alisiikh/scalastyle/ScalastyleFunSpec.groovy
@@ -13,6 +13,7 @@ abstract class ScalastyleFunSpec extends Specification {
     static class Projects {
         static SINGLE_MODULE = 'single-module'
         static SINGLE_MODULE_MULTI_SOURCE = 'single-module-multi-source'
+        static TRAILING_COMMA = 'trailing-comma'
     }
 
     @Rule

--- a/src/functionalTest/resources/trailing-comma/scalastyle_config.xml
+++ b/src/functionalTest/resources/trailing-comma/scalastyle_config.xml
@@ -1,0 +1,142 @@
+<scalastyle commentFilter="enabled">
+ <name>Scalastyle standard configuration</name>
+ <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+  <parameters>
+   <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLineLength"><![CDATA[160]]></parameter>
+   <parameter name="tabSize"><![CDATA[4]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+  <parameters>
+   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+  <parameters>
+   <parameter name="maxParameters"><![CDATA[8]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+  <parameters>
+   <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+ <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[println]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+  <parameters>
+   <parameter name="maxTypes"><![CDATA[30]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+  <parameters>
+   <parameter name="maximum"><![CDATA[10]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+  <parameters>
+   <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+   <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLength"><![CDATA[50]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+  <parameters>
+   <parameter name="maxMethods"><![CDATA[30]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+ <check level="warning" class="org.scalastyle.scalariform.WhileChecker" enabled="false"></check>
+ <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="false"></check>
+ <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"></check>
+ <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="false"></check>
+ <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="false">
+  <parameters>
+   <parameter name="regex"><![CDATA[println]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
+  <parameters>
+   <parameter name="allowed"><![CDATA[2]]></parameter>
+   <parameter name="ignoreRegex"><![CDATA[^""$]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"></check>
+</scalastyle>

--- a/src/functionalTest/resources/trailing-comma/src/main/scala/MyClass.scala
+++ b/src/functionalTest/resources/trailing-comma/src/main/scala/MyClass.scala
@@ -1,0 +1,7 @@
+class MyClass {
+  val list = List(
+    "a",
+    "b",
+    "c",
+  )
+}

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleExtension.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleExtension.groovy
@@ -70,7 +70,7 @@ class SourceSetScalastyleConfig extends CommonScalastyleConfig {
 
 class ScalastyleExtension extends CommonScalastyleConfig {
     static final SCALA_VERSION = '2.12'
-    static final SCALASTYLE_VERSION = '1.0.0'
+    static final SCALASTYLE_VERSION = '1.1.0'
 
     final Property<String> scalaVersion
     final Property<String> scalastyleVersion

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastylePlugin.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastylePlugin.groovy
@@ -42,8 +42,14 @@ class ScalastylePlugin implements Plugin<Project> {
 
         project.afterEvaluate { p ->
             p.dependencies {
+                /**
+                 * Beautiful Scala fork of ScalaStyle: https://scalastyle.beautiful-scala.com
+                 *
+                 * See: https://github.com/scalastyle/scalastyle/issues/327#issuecomment-570951273
+                 * Release notes: https://github.com/beautiful-scala/scalastyle/releases/tag/v1.1.0
+                 */
                 // scala is already included in scalastyle dependency transitively
-                scalastyle "org.scalastyle:scalastyle_${extension.scalaVersion.get()}:${extension.scalastyleVersion.get()}"
+                scalastyle "com.beautiful-scala:scalastyle_${extension.scalaVersion.get()}:${extension.scalastyleVersion.get()}"
             }
         }
 


### PR DESCRIPTION
It seems that the original ScalaStyle project is no longer actively maintained.  A community member [has forked the original project](https://github.com/scalastyle/scalastyle/issues/327#issuecomment-570951273) and I'm updating this project's ScalaStyle library to use theirs.

Along with trailing comma support, there are a few other checks that have been added in their [version of 1.1.0](https://github.com/beautiful-scala/scalastyle/releases/tag/v1.1.0).

Fixes #13