### PR TITLE
Issues 21, 22: Log stacktrace on Scalastyle failure and reduce command line length

### DIFF
--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastylePlugin.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastylePlugin.groovy
@@ -76,6 +76,7 @@ class ScalastylePlugin implements Plugin<Project> {
 
                     source = sourceSet.scala.srcDirs
 
+                    sourceDirs.set(sourceSet.scala.srcDirs)
                     output.set(sourceSetConfig.output)
                     config.set(resolveScalastyleConfig(sourceSetConfig, sourceSet.name))
                     failOnWarning.set(sourceSetConfig.failOnWarning.isPresent() ?


### PR DESCRIPTION
- log stacktrace when Scalastyle exec fails (required --stacktrace, --full-stacktrace to see)
- reduce size of the command line by passing the root source folder instead of each individual class file path