### PR TITLE
Execute scalastyle checks in daemon workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please refer to the plugin page on how to install it: https://plugins.gradle.org
 
 
 ### Configuration
-If you have a config scalastyle_config.xml in the root of your project 
+If you have a config scalastyle_config.xml in the root of your project
 you don't need to specify configuration for the plugin
 
 Plugin configuration (example contains default values):
@@ -28,6 +28,7 @@ scalastyle {
   failOnWarning = false
   verbose = false
   quiet = false
+  options {} // JavaForkOptions that determine fork options of the daemon worker(s)
 }
 ```
 
@@ -47,7 +48,7 @@ Example configuration for a project with multiple source sets and different scal
     failOnWarning = true
     verbose = false
     quiet = true
-  
+
     // source sets must be defined in the project
     sourceSets {
       main {
@@ -60,6 +61,16 @@ Example configuration for a project with multiple source sets and different scal
       perfTest {
         skip = true // don't run scalastyle for perfTest source set at all
       }
+    }
+  }
+```
+
+Example configuration of options parameter:
+
+```groovy
+  scalastyle {
+    options {
+      maxHeapSize = '64m'
     }
   }
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ scalastyle {
   failOnWarning = false
   verbose = false
   quiet = false
-  options {} // JavaForkOptions that determine fork options of the daemon worker(s)
+  forkOptions {} // JavaForkOptions that determine fork options of the daemon worker(s)
 }
 ```
 
@@ -65,11 +65,11 @@ Example configuration for a project with multiple source sets and different scal
   }
 ```
 
-Example configuration of options parameter:
+Example configuration of `forkOptions` parameter:
 
 ```groovy
   scalastyle {
-    options {
+    forkOptions {
       maxHeapSize = '64m'
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,11 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
 
-    testCompile gradleTestKit()
-    testCompile('org.spockframework:spock-core:1.3-groovy-2.5') {
+    testImplementation gradleTestKit()
+    testImplementation('org.spockframework:spock-core:1.3-groovy-2.5') {
         exclude module: 'groovy-all'
     }
-    testCompile 'commons-io:commons-io:2.6'
+    testImplementation 'commons-io:commons-io:2.6'
 }
 
 sourceSets {
@@ -61,7 +61,7 @@ sourceSets {
         java.srcDir file('src/functionalTest/java')
         groovy.srcDir file('src/functionalTest/groovy')
         resources.srcDir file('src/functionalTest/resources')
-        compileClasspath += sourceSets.main.output + configurations.testRuntime
+        compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
         runtimeClasspath += output + compileClasspath
     }
 }

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckAction.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckAction.groovy
@@ -22,14 +22,16 @@ abstract class ScalastyleCheckAction implements WorkAction<ScalastyleCheckParame
   @Override
   void execute() {
     try {
-      String s = 'UTF8'
       String[] args = getParameters().getArgs().get() as String[]
 
-      Class<?> codecClass = Thread.currentThread().getContextClassLoader().loadClass('scala.io.Codec$')
+      ClassLoader classLoader = Thread.currentThread().getContextClassLoader()
+
+      Class<?> codecClass = classLoader.loadClass('scala.io.Codec$')
       Object codecInstance = codecClass.getField('MODULE$').get(null)
-      Method string2codec = codecClass.getMethod('string2codec', s.getClass())
-      Object codec = string2codec.invoke(codecInstance, s)
-      Class<?> mainClass = Thread.currentThread().getContextClassLoader().loadClass('org.scalastyle.Main$')
+      Method defaultCharsetCodec = codecClass.getMethod('defaultCharsetCodec')
+      Object codec = defaultCharsetCodec.invoke(codecInstance)
+
+      Class<?> mainClass = classLoader.loadClass('org.scalastyle.Main$')
       Object mainInstance = mainClass.getField('MODULE$').get(null)
       Method parseArgs = mainClass.getDeclaredMethod('parseArgs', args.getClass())
       Object mainConfig = parseArgs.invoke(mainInstance, [args] as Object[])

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckAction.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckAction.groovy
@@ -1,0 +1,46 @@
+/*
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.github.alisiikh.scalastyle
+
+import org.gradle.api.GradleException
+import org.gradle.workers.WorkAction
+
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+abstract class ScalastyleCheckAction implements WorkAction<ScalastyleCheckParameters> {
+  @Override
+  void execute() {
+    try {
+      Object[] args = [getParameters().getArgs().get() as String[]] as Object[]
+
+      Class<?> codecClass = Thread.currentThread().getContextClassLoader().loadClass('scala.io.Codec$')
+      Object codecInstance = codecClass.getField('MODULE$').get(null)
+      Field utf8 = codecClass.getDeclaredField('UTF8')
+      utf8.setAccessible(true)
+      Object codec = utf8.get(codecInstance)
+      Class<?> mainClass = Thread.currentThread().getContextClassLoader().loadClass('org.scalastyle.Main$')
+      Object mainInstance = mainClass.getField('MODULE$').get(null)
+      Method parseArgs = mainClass.getDeclaredMethod('parseArgs', java.lang.String[])
+      Object mainConfig = parseArgs.invoke(mainInstance, args)
+      Method execute = mainClass.getDeclaredMethods().find { it.getName() == 'execute' }
+      execute.setAccessible(true)
+      assert execute.invoke(mainInstance, mainConfig, codec) == false
+    } catch(AssertionError e) {
+      throw new GradleException("Scalastyle check failed.", e)
+    } catch(Exception e) {
+      throw new RuntimeException(e)
+    }
+  }
+}

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckAction.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckAction.groovy
@@ -23,18 +23,18 @@ abstract class ScalastyleCheckAction implements WorkAction<ScalastyleCheckParame
   @Override
   void execute() {
     try {
-      Object[] args = [getParameters().getArgs().get() as String[]] as Object[]
+      String s = 'UTF8'
+      String[] args = getParameters().getArgs().get() as String[]
 
       Class<?> codecClass = Thread.currentThread().getContextClassLoader().loadClass('scala.io.Codec$')
       Object codecInstance = codecClass.getField('MODULE$').get(null)
-      Field utf8 = codecClass.getDeclaredField('UTF8')
-      utf8.setAccessible(true)
-      Object codec = utf8.get(codecInstance)
+      Method string2codec = codecClass.getMethod('string2codec', s.getClass())
+      Object codec = string2codec.invoke(codecInstance, s)
       Class<?> mainClass = Thread.currentThread().getContextClassLoader().loadClass('org.scalastyle.Main$')
       Object mainInstance = mainClass.getField('MODULE$').get(null)
-      Method parseArgs = mainClass.getDeclaredMethod('parseArgs', java.lang.String[])
-      Object mainConfig = parseArgs.invoke(mainInstance, args)
-      Method execute = mainClass.getDeclaredMethods().find { it.getName() == 'execute' }
+      Method parseArgs = mainClass.getDeclaredMethod('parseArgs', args.getClass())
+      Object mainConfig = parseArgs.invoke(mainInstance, [args] as Object[])
+      Method execute = mainClass.getDeclaredMethod('execute', mainConfig.getClass(), codec.getClass())
       execute.setAccessible(true)
       assert execute.invoke(mainInstance, mainConfig, codec) == false
     } catch(AssertionError e) {

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckAction.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckAction.groovy
@@ -16,7 +16,6 @@ package com.github.alisiikh.scalastyle
 import org.gradle.api.GradleException
 import org.gradle.workers.WorkAction
 
-import java.lang.reflect.Field
 import java.lang.reflect.Method
 
 abstract class ScalastyleCheckAction implements WorkAction<ScalastyleCheckParameters> {

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckAction.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckAction.groovy
@@ -39,7 +39,7 @@ abstract class ScalastyleCheckAction implements WorkAction<ScalastyleCheckParame
       execute.setAccessible(true)
       assert execute.invoke(mainInstance, mainConfig, codec) == false
     } catch(AssertionError e) {
-      throw new GradleException("Scalastyle check failed.", e)
+      throw new GradleException("Scalastyle check failed. See the report at: ${getParameters().getReport().get()}", e)
     } catch(Exception e) {
       throw new RuntimeException(e)
     }

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckParameters.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckParameters.groovy
@@ -14,8 +14,10 @@
 package com.github.alisiikh.scalastyle
 
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.workers.WorkParameters
 
 interface ScalastyleCheckParameters extends WorkParameters {
+  Property<File> getReport()
   ListProperty<String> getArgs()
 }

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckParameters.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckParameters.groovy
@@ -1,0 +1,21 @@
+/*
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.github.alisiikh.scalastyle
+
+import org.gradle.api.provider.ListProperty
+import org.gradle.workers.WorkParameters
+
+interface ScalastyleCheckParameters extends WorkParameters {
+  ListProperty<String> getArgs()
+}

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckTask.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckTask.groovy
@@ -61,7 +61,7 @@ class ScalastyleCheckTask extends SourceTask {
     final Property<Boolean> quiet = project.objects.property(Boolean)
 
     @Internal
-    final Property<JavaForkOptions> options = project.objects.property(JavaForkOptions)
+    final Property<JavaForkOptions> forkOptions = project.objects.property(JavaForkOptions)
 
     @TaskAction
     def run() {
@@ -84,7 +84,7 @@ class ScalastyleCheckTask extends SourceTask {
 
             WorkQueue workQueue = workerExecutor.processIsolation() { workerSpec ->
                 workerSpec.getClasspath().from(getProject().getConfigurations().getByName('scalastyle'))
-                options.get().copyTo(workerSpec.getForkOptions())
+                this.forkOptions.get().copyTo(workerSpec.getForkOptions())
             }
             workQueue.submit(ScalastyleCheckAction.class) { parameters ->
                 parameters.getReport().set(output.get())

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckTask.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckTask.groovy
@@ -28,11 +28,11 @@ import org.gradle.process.internal.ExecException
 @CacheableTask
 class ScalastyleCheckTask extends SourceTask {
 
-    @PathSensitive(PathSensitivity.ABSOLUTE)
+    @PathSensitive(PathSensitivity.RELATIVE)
     @InputFile
     final Property<File> config = project.objects.property(File)
 
-    @PathSensitive(PathSensitivity.ABSOLUTE)
+    @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     final SetProperty<File> sourceDirs = project.objects.setProperty(File)
 

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckTask.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckTask.groovy
@@ -87,6 +87,7 @@ class ScalastyleCheckTask extends SourceTask {
                 options.get().copyTo(workerSpec.getForkOptions())
             }
             workQueue.submit(ScalastyleCheckAction.class) { parameters ->
+                parameters.getReport().set(output.get())
                 parameters.getArgs().set([
                   '-c', config.get().absolutePath,
                   '-v', verbose.get().toString(),

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckTask.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleCheckTask.groovy
@@ -31,11 +31,11 @@ import javax.inject.Inject
 
 @CacheableTask
 class ScalastyleCheckTask extends SourceTask {
-    private final WorkerExecutor workerExecutor;
+    private final WorkerExecutor workerExecutor
 
     @Inject
     ScalastyleCheckTask(WorkerExecutor workerExecutor) {
-        this.workerExecutor = workerExecutor;
+        this.workerExecutor = workerExecutor
     }
 
     @PathSensitive(PathSensitivity.RELATIVE)

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleExtension.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleExtension.groovy
@@ -83,7 +83,7 @@ class ScalastyleExtension extends CommonScalastyleConfig {
     final Property<String> outputEncoding
     final Property<Boolean> verbose
     final Property<Boolean> quiet
-    final Property<JavaForkOptions> options
+    final Property<JavaForkOptions> forkOptions
 
     final NamedDomainObjectContainer<SourceSetScalastyleConfig> sourceSets
 
@@ -111,8 +111,8 @@ class ScalastyleExtension extends CommonScalastyleConfig {
         quiet = project.objects.property(Boolean)
         quiet.set(false)
 
-        options = project.objects.property(JavaForkOptions)
-        options.set(getJavaForkOptionsFactory().newJavaForkOptions())
+        forkOptions = project.objects.property(JavaForkOptions)
+        forkOptions.set(getJavaForkOptionsFactory().newJavaForkOptions())
 
         skip.convention(false)
         config.convention(new File(project.projectDir, "scalastyle_config.xml"))
@@ -152,8 +152,8 @@ class ScalastyleExtension extends CommonScalastyleConfig {
         this.quiet.set(quiet)
     }
 
-    def options(final Action<? super JavaForkOptions> a) {
-        a.execute(options.get())
+    def forkOptions(final Action<? super JavaForkOptions> a) {
+        a.execute(forkOptions.get())
     }
 
     def sourceSets(final Closure c) {

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleExtension.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleExtension.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.scala.ScalaPlugin
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 
 abstract class CommonScalastyleConfig {
@@ -78,6 +79,7 @@ class ScalastyleExtension extends CommonScalastyleConfig {
     final Property<String> outputEncoding
     final Property<Boolean> verbose
     final Property<Boolean> quiet
+    final ListProperty<String> jvmArgs
 
     final NamedDomainObjectContainer<SourceSetScalastyleConfig> sourceSets
 
@@ -104,6 +106,9 @@ class ScalastyleExtension extends CommonScalastyleConfig {
 
         quiet = project.objects.property(Boolean)
         quiet.set(false)
+
+        jvmArgs = project.objects.listProperty(String)
+        jvmArgs.set([])
 
         skip.convention(false)
         config.convention(new File(project.projectDir, "scalastyle_config.xml"))

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleExtension.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastyleExtension.groovy
@@ -112,7 +112,7 @@ class ScalastyleExtension extends CommonScalastyleConfig {
         quiet.set(false)
 
         forkOptions = project.objects.property(JavaForkOptions)
-        forkOptions.set(getJavaForkOptionsFactory().newJavaForkOptions())
+        forkOptions.set(getForkOptionsFactory().newJavaForkOptions())
 
         skip.convention(false)
         config.convention(new File(project.projectDir, "scalastyle_config.xml"))
@@ -123,9 +123,11 @@ class ScalastyleExtension extends CommonScalastyleConfig {
         })
     }
 
+    // implementation of getForkOptionsFactory method follows the example set by org.gradle.api.tasks.testing.Test task
+    // https://github.com/gradle/gradle/blob/v6.0.1/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java#L179
     @Inject
-    protected JavaForkOptionsFactory getJavaForkOptionsFactory() {
-        throw new UnsupportedOperationException();
+    protected JavaForkOptionsFactory getForkOptionsFactory() {
+        throw new UnsupportedOperationException()
     }
 
     void setScalaVersion(String scalaVersion) {

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastylePlugin.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastylePlugin.groovy
@@ -85,7 +85,7 @@ class ScalastylePlugin implements Plugin<Project> {
                     quiet.set(extension.quiet)
                     outputEncoding.set(extension.outputEncoding)
                     inputEncoding.set(extension.inputEncoding)
-                    jvmArgs.set(extension.jvmArgs)
+                    options.set(extension.options)
                 }
             }
 

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastylePlugin.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastylePlugin.groovy
@@ -85,6 +85,7 @@ class ScalastylePlugin implements Plugin<Project> {
                     quiet.set(extension.quiet)
                     outputEncoding.set(extension.outputEncoding)
                     inputEncoding.set(extension.inputEncoding)
+                    jvmArgs.set(extension.jvmArgs)
                 }
             }
 

--- a/src/main/groovy/com/github/alisiikh/scalastyle/ScalastylePlugin.groovy
+++ b/src/main/groovy/com/github/alisiikh/scalastyle/ScalastylePlugin.groovy
@@ -85,7 +85,7 @@ class ScalastylePlugin implements Plugin<Project> {
                     quiet.set(extension.quiet)
                     outputEncoding.set(extension.outputEncoding)
                     inputEncoding.set(extension.inputEncoding)
-                    options.set(extension.options)
+                    forkOptions.set(extension.forkOptions)
                 }
             }
 


### PR DESCRIPTION
This PR introduces the following improvements to *gradle-scalastyle-plugin* (TLDR: on the project I'm working on, the changes introduced in this PR decreased the average *scalastyleCheck* running time from ~**15 minutes** to ~**2 minutes**)

###### Scalastyle Check Execution in Daemon Workers

On a large project, with plenty of subprojects, running each *ScalastyleCheck* task in a separate JVM is not optimal. It can even become a blocker for plugin adoption in some cases. 

To mitigate the issue, I'm proposing to run *ScalastyleCheck* tasks in *Daemon Worker* processes instead. This task was achieved using [Worker API](https://guides.gradle.org/using-the-worker-api/).

To stay as oblivious as possible regarding scalastyle version requested, I'm using reflection to call only the following functions from *scalastyle* and *scala* packages:
- `org.scalastyle.Main.execute`
- `org.scalastyle.Main.parseArgs`
- `scala.io.Codec.defaultCharsetCodec`

Additionally, I've introduced a new property (`options`) on the *ScalastyleCheckTask* and *ScalastyleCheckExtension*. This new property dictates what *JavaForkOptions* should *Daemon Worker*s be started with.

###### Cache Keys based on Relative Paths

I'm setting *Path Sensitivity* to **RELATIVE** for `config` and `sourceSets` inputs. Thanks to that, the plugin now supports remote build cache because only relative paths to the resources we're interested in are considered instead of absolute ones (which surely differ between CI and dev machines). 

###### Fewer Deprecation Warnings

`testCompile` configuration is due to be removed in *Gradle 7.0*. Here, I'm replacing it with `testImplementation`.

---------
Hope you like the PR. Thank you for all the hard work maintaining the plugin 🦄 