### PR TITLE
Update README.md to mention beautiful-scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build](https://travis-ci.org/alisiikh/gradle-scalastyle-plugin.svg?branch=master)
 
-Gradle plugin for Scalastyle http://www.scalastyle.org/
+Gradle plugin for Scalastyle (beautiful-scala fork) https://scalastyle.beautiful-scala.com/
 
 Originally forked from: https://github.com/ngbinh/gradle-scalastyle-plugin
 
@@ -20,7 +20,7 @@ Plugin configuration (example contains default values):
 ```groovy
 scalastyle {
   scalaVersion = '2.12'
-  scalastyleVersion = '1.0.0'
+  scalastyleVersion = '1.2.0' // version of com.beautiful-scala:scalastyle
   config = file("${projectDir}/scalastyle_config.xml") // path to scalastyle config xml file
   skip = false  // skips scalastyle check if set to true
   inputEncoding = 'UTF-8'


### PR DESCRIPTION
The plugin is using `com.beautiful-scala:scalastyle`, but the readme was not mentioning that.
In our company project we recently tried to migrate to higher version of scala (2.13.10) and scalastyle upgrade was needed. Fortunately regarding this plugin the migration was as easy as pointing `scalastyleVersion` to 1.5.1 ( https://mvnrepository.com/artifact/com.beautiful-scala/scalastyle_2.13/1.5.1 ).
Thanks for amazing work :)